### PR TITLE
Congelar tempo em status finalizado ou cancelado

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1997,7 +1997,7 @@ const colorPalette = [
             data.forEach(acionamento => {
                 const row = document.createElement('tr');
                 
-                // Calcular tempos (com congelamento quando status for Recurso Alocado ou Finalizado)
+                // Calcular tempos (congelar somente quando status for Finalizado ou Cancelado)
                 const tempoDesdeCreacao = calcularTempoDecorrido(
                     acionamento.data_criacao_ocorrencia, 
                     acionamento.horario_criacao_ocorrencia,
@@ -2050,7 +2050,7 @@ const colorPalette = [
             console.log(`Tabela renderizada com ${data.length} acionamentos`);
         }
 
-        // Função para calcular tempo decorrido (congela quando status é RECURSO_ALOCADO ou FINALIZADO)
+        // Função para calcular tempo decorrido (congela quando status é FINALIZADO ou CANCELADO)
         function calcularTempoDecorrido(dataInicio, horaInicio = null, acionamento) {
             if (!dataInicio) return '-';
             
@@ -2065,16 +2065,16 @@ const colorPalette = [
             
             let fim;
             
-            // Congelar tempo quando status for RECURSO_ALOCADO ou FINALIZADO
-            if (acionamento.status === 'RECURSO_ALOCADO' && acionamento.data_alocacao) {
-                fim = new Date(acionamento.data_alocacao);
-            } else if (acionamento.status === 'FINALIZADO' && acionamento.data_finalizacao) {
+            // Congelar tempo quando status for FINALIZADO ou CANCELADO
+            if (acionamento.status === 'FINALIZADO' && acionamento.data_finalizacao) {
                 fim = new Date(acionamento.data_finalizacao);
                 if (acionamento.hora_finalizacao) {
                     // Combinar data e hora de finalização
                     const [hours, minutes] = acionamento.hora_finalizacao.split(':');
                     fim.setHours(parseInt(hours), parseInt(minutes));
                 }
+            } else if (acionamento.status === 'CANCELADO' && acionamento.data_cancelamento) {
+                fim = new Date(acionamento.data_cancelamento);
             } else {
                 fim = new Date(); // Usa a data/hora atual
             }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adjust time calculation to freeze only when the status is 'FINALIZADO' or 'CANCELADO', as requested, instead of 'RECURSO_ALOCADO'.

---
<a href="https://cursor.com/background-agent?bcId=bc-22879d3c-6182-4fbc-b006-a3383039d366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22879d3c-6182-4fbc-b006-a3383039d366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

